### PR TITLE
Updated (new) report form; Dynamic date pickers; screen positioning

### DIFF
--- a/InventoryForm.Designer.cs
+++ b/InventoryForm.Designer.cs
@@ -254,7 +254,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "InventoryForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "InventoryForm";
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             this.ResumeLayout(false);

--- a/MainScreenForm.cs
+++ b/MainScreenForm.cs
@@ -48,7 +48,7 @@ namespace Team1CMPT291_Final
         private void button1_Click(object sender, EventArgs e)
         {
             this.Close();
-            ReportForm reportForm = new ReportForm();
+            ReportFormNew reportForm = new ReportFormNew();
             reportForm.Show();
         }
     }

--- a/ModifyCarForm.Designer.cs
+++ b/ModifyCarForm.Designer.cs
@@ -51,40 +51,40 @@
             // 
             this.label_VIN.AutoSize = true;
             this.label_VIN.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_VIN.Location = new System.Drawing.Point(38, 30);
-            this.label_VIN.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_VIN.Location = new System.Drawing.Point(21, 16);
+            this.label_VIN.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label_VIN.Name = "label_VIN";
-            this.label_VIN.Size = new System.Drawing.Size(68, 31);
+            this.label_VIN.Size = new System.Drawing.Size(35, 18);
             this.label_VIN.TabIndex = 0;
             this.label_VIN.Text = "VIN:";
             // 
             // textBox_LicensePlate
             // 
             this.textBox_LicensePlate.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_LicensePlate.Location = new System.Drawing.Point(46, 161);
-            this.textBox_LicensePlate.Margin = new System.Windows.Forms.Padding(4);
+            this.textBox_LicensePlate.Location = new System.Drawing.Point(25, 87);
+            this.textBox_LicensePlate.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.textBox_LicensePlate.Name = "textBox_LicensePlate";
-            this.textBox_LicensePlate.Size = new System.Drawing.Size(284, 39);
+            this.textBox_LicensePlate.Size = new System.Drawing.Size(157, 26);
             this.textBox_LicensePlate.TabIndex = 1;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(38, 124);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(21, 67);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(0, 31);
+            this.label1.Size = new System.Drawing.Size(0, 18);
             this.label1.TabIndex = 2;
             // 
             // label_LicencePlate
             // 
             this.label_LicencePlate.AutoSize = true;
             this.label_LicencePlate.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_LicencePlate.Location = new System.Drawing.Point(38, 124);
-            this.label_LicencePlate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label_LicencePlate.Location = new System.Drawing.Point(21, 67);
+            this.label_LicencePlate.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label_LicencePlate.Name = "label_LicencePlate";
-            this.label_LicencePlate.Size = new System.Drawing.Size(185, 31);
+            this.label_LicencePlate.Size = new System.Drawing.Size(100, 18);
             this.label_LicencePlate.TabIndex = 3;
             this.label_LicencePlate.Text = "License Plate:";
             // 
@@ -92,10 +92,10 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(38, 227);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(21, 123);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(88, 31);
+            this.label2.Size = new System.Drawing.Size(49, 18);
             this.label2.TabIndex = 4;
             this.label2.Text = "Make:";
             // 
@@ -103,10 +103,10 @@
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(38, 327);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(21, 177);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(95, 31);
+            this.label3.Size = new System.Drawing.Size(53, 18);
             this.label3.TabIndex = 5;
             this.label3.Text = "Model:";
             // 
@@ -114,10 +114,10 @@
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(451, 30);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label4.Location = new System.Drawing.Point(246, 16);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(184, 31);
+            this.label4.Size = new System.Drawing.Size(102, 18);
             this.label4.TabIndex = 6;
             this.label4.Text = "Transmission:";
             // 
@@ -125,10 +125,10 @@
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(451, 124);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Location = new System.Drawing.Point(246, 67);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(151, 31);
+            this.label5.Size = new System.Drawing.Size(81, 18);
             this.label5.TabIndex = 7;
             this.label5.Text = "Branch_ID:";
             // 
@@ -136,58 +136,58 @@
             // 
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(451, 227);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Location = new System.Drawing.Point(246, 123);
+            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(83, 31);
+            this.label6.Size = new System.Drawing.Size(44, 18);
             this.label6.TabIndex = 8;
             this.label6.Text = "Type:";
             // 
             // textBox_Make
             // 
             this.textBox_Make.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_Make.Location = new System.Drawing.Point(44, 262);
-            this.textBox_Make.Margin = new System.Windows.Forms.Padding(4);
+            this.textBox_Make.Location = new System.Drawing.Point(24, 142);
+            this.textBox_Make.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.textBox_Make.Name = "textBox_Make";
-            this.textBox_Make.Size = new System.Drawing.Size(286, 39);
+            this.textBox_Make.Size = new System.Drawing.Size(158, 26);
             this.textBox_Make.TabIndex = 9;
             // 
             // textBox_Model
             // 
             this.textBox_Model.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_Model.Location = new System.Drawing.Point(46, 362);
-            this.textBox_Model.Margin = new System.Windows.Forms.Padding(4);
+            this.textBox_Model.Location = new System.Drawing.Point(25, 196);
+            this.textBox_Model.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.textBox_Model.Name = "textBox_Model";
-            this.textBox_Model.Size = new System.Drawing.Size(284, 39);
+            this.textBox_Model.Size = new System.Drawing.Size(157, 26);
             this.textBox_Model.TabIndex = 10;
             // 
             // textBox_Transmission
             // 
             this.textBox_Transmission.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox_Transmission.Location = new System.Drawing.Point(456, 66);
-            this.textBox_Transmission.Margin = new System.Windows.Forms.Padding(4);
+            this.textBox_Transmission.Location = new System.Drawing.Point(249, 36);
+            this.textBox_Transmission.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.textBox_Transmission.Name = "textBox_Transmission";
-            this.textBox_Transmission.Size = new System.Drawing.Size(288, 39);
+            this.textBox_Transmission.Size = new System.Drawing.Size(159, 26);
             this.textBox_Transmission.TabIndex = 11;
             // 
             // textbox_VIN
             // 
             this.textbox_VIN.AutoSize = true;
             this.textbox_VIN.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.14286F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textbox_VIN.Location = new System.Drawing.Point(38, 74);
-            this.textbox_VIN.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.textbox_VIN.Location = new System.Drawing.Point(21, 40);
+            this.textbox_VIN.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.textbox_VIN.Name = "textbox_VIN";
-            this.textbox_VIN.Size = new System.Drawing.Size(151, 31);
+            this.textbox_VIN.Size = new System.Drawing.Size(80, 18);
             this.textbox_VIN.TabIndex = 14;
             this.textbox_VIN.Text = "VIN LABEL";
             // 
             // SaveButton
             // 
             this.SaveButton.BackColor = System.Drawing.Color.LightGreen;
-            this.SaveButton.Location = new System.Drawing.Point(46, 454);
-            this.SaveButton.Margin = new System.Windows.Forms.Padding(4);
+            this.SaveButton.Location = new System.Drawing.Point(25, 246);
+            this.SaveButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.SaveButton.Name = "SaveButton";
-            this.SaveButton.Size = new System.Drawing.Size(363, 94);
+            this.SaveButton.Size = new System.Drawing.Size(198, 51);
             this.SaveButton.TabIndex = 15;
             this.SaveButton.Text = "Save";
             this.SaveButton.UseVisualStyleBackColor = false;
@@ -195,10 +195,10 @@
             // 
             // BackBTN
             // 
-            this.BackBTN.Location = new System.Drawing.Point(818, 471);
-            this.BackBTN.Margin = new System.Windows.Forms.Padding(4);
+            this.BackBTN.Location = new System.Drawing.Point(446, 255);
+            this.BackBTN.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.BackBTN.Name = "BackBTN";
-            this.BackBTN.Size = new System.Drawing.Size(196, 78);
+            this.BackBTN.Size = new System.Drawing.Size(107, 42);
             this.BackBTN.TabIndex = 16;
             this.BackBTN.Text = "Back";
             this.BackBTN.UseVisualStyleBackColor = true;
@@ -206,29 +206,27 @@
             // 
             // ComboBox_Type
             // 
-            this.ComboBox_Type.Font = new System.Drawing.Font("Inter Medium", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.ComboBox_Type.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ComboBox_Type.FormattingEnabled = true;
-            this.ComboBox_Type.Location = new System.Drawing.Point(456, 262);
-            this.ComboBox_Type.Margin = new System.Windows.Forms.Padding(6);
+            this.ComboBox_Type.Location = new System.Drawing.Point(249, 142);
             this.ComboBox_Type.Name = "ComboBox_Type";
-            this.ComboBox_Type.Size = new System.Drawing.Size(288, 42);
+            this.ComboBox_Type.Size = new System.Drawing.Size(159, 28);
             this.ComboBox_Type.TabIndex = 17;
             // 
             // ComboBox_Branch
             // 
-            this.ComboBox_Branch.Font = new System.Drawing.Font("Inter Medium", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.ComboBox_Branch.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ComboBox_Branch.FormattingEnabled = true;
-            this.ComboBox_Branch.Location = new System.Drawing.Point(456, 161);
-            this.ComboBox_Branch.Margin = new System.Windows.Forms.Padding(6);
+            this.ComboBox_Branch.Location = new System.Drawing.Point(249, 87);
             this.ComboBox_Branch.Name = "ComboBox_Branch";
-            this.ComboBox_Branch.Size = new System.Drawing.Size(288, 42);
+            this.ComboBox_Branch.Size = new System.Drawing.Size(159, 28);
             this.ComboBox_Branch.TabIndex = 18;
             // 
             // ModifyCarForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1034, 580);
+            this.ClientSize = new System.Drawing.Size(564, 314);
             this.Controls.Add(this.ComboBox_Branch);
             this.Controls.Add(this.ComboBox_Type);
             this.Controls.Add(this.BackBTN);
@@ -247,8 +245,9 @@
             this.Controls.Add(this.textBox_LicensePlate);
             this.Controls.Add(this.label_VIN);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(4);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "ModifyCarForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "ModifyCarForm";
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/RentalTransactionForm.Designer.cs
+++ b/RentalTransactionForm.Designer.cs
@@ -198,6 +198,7 @@ namespace Team1CMPT291_Final
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "RentalTransactionForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "RentalTransactionForm";
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             this.ResumeLayout(false);

--- a/RentalTransactionForm.cs
+++ b/RentalTransactionForm.cs
@@ -23,6 +23,11 @@ namespace Team1CMPT291_Final
         public RentalTransactionForm()
         {
             InitializeComponent();
+
+            // Dynamic date picker settings.
+            dateTimePickerPickup.MinDate  = DateTime.Today;
+            dateTimePickerDropoff.MinDate = DateTime.Today;
+
             DataTable branches = new DBConnection().Query("SELECT Branch_ID, Name FROM Branches");
             comboBox_Branch.DataSource = branches;
             comboBox_Branch.DisplayMember = "Name";

--- a/ReportFormNew.Designer.cs
+++ b/ReportFormNew.Designer.cs
@@ -1,0 +1,283 @@
+﻿namespace Team1CMPT291_Final
+{
+    partial class ReportFormNew
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.TabControlMenu = new System.Windows.Forms.TabControl();
+            this.ReportTab1 = new System.Windows.Forms.TabPage();
+            this.CarUsageResults = new System.Windows.Forms.DataGridView();
+            this.ReportTab2 = new System.Windows.Forms.TabPage();
+            this.FrequentFlyerResults = new System.Windows.Forms.DataGridView();
+            this.ReportTab3 = new System.Windows.Forms.TabPage();
+            this.MonthlyRevenueResults = new System.Windows.Forms.DataGridView();
+            this.ReportTab4 = new System.Windows.Forms.TabPage();
+            this.BusyBranchTimesResults = new System.Windows.Forms.DataGridView();
+            this.ReportTab5 = new System.Windows.Forms.TabPage();
+            this.BackButton = new System.Windows.Forms.Button();
+            this.UnderPerformingEmpsResults = new System.Windows.Forms.DataGridView();
+            this.UnderPerformingEmpsSubmit = new System.Windows.Forms.Button();
+            this.BusyBranchTimesSubmit = new System.Windows.Forms.Button();
+            this.MonthlyRevenueSubmit = new System.Windows.Forms.Button();
+            this.FrequentFlyersSubmit = new System.Windows.Forms.Button();
+            this.CarUsagesSubmit = new System.Windows.Forms.Button();
+            this.TabControlMenu.SuspendLayout();
+            this.ReportTab1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.CarUsageResults)).BeginInit();
+            this.ReportTab2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.FrequentFlyerResults)).BeginInit();
+            this.ReportTab3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.MonthlyRevenueResults)).BeginInit();
+            this.ReportTab4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.BusyBranchTimesResults)).BeginInit();
+            this.ReportTab5.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.UnderPerformingEmpsResults)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // TabControlMenu
+            // 
+            this.TabControlMenu.Controls.Add(this.ReportTab1);
+            this.TabControlMenu.Controls.Add(this.ReportTab2);
+            this.TabControlMenu.Controls.Add(this.ReportTab3);
+            this.TabControlMenu.Controls.Add(this.ReportTab4);
+            this.TabControlMenu.Controls.Add(this.ReportTab5);
+            this.TabControlMenu.Location = new System.Drawing.Point(-1, 12);
+            this.TabControlMenu.Name = "TabControlMenu";
+            this.TabControlMenu.SelectedIndex = 0;
+            this.TabControlMenu.Size = new System.Drawing.Size(910, 531);
+            this.TabControlMenu.TabIndex = 0;
+            // 
+            // ReportTab1
+            // 
+            this.ReportTab1.Controls.Add(this.CarUsagesSubmit);
+            this.ReportTab1.Controls.Add(this.CarUsageResults);
+            this.ReportTab1.Location = new System.Drawing.Point(4, 22);
+            this.ReportTab1.Name = "ReportTab1";
+            this.ReportTab1.Padding = new System.Windows.Forms.Padding(3);
+            this.ReportTab1.Size = new System.Drawing.Size(902, 505);
+            this.ReportTab1.TabIndex = 0;
+            this.ReportTab1.Text = "Car Usages";
+            this.ReportTab1.UseVisualStyleBackColor = true;
+            // 
+            // CarUsageResults
+            // 
+            this.CarUsageResults.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.CarUsageResults.Location = new System.Drawing.Point(65, 185);
+            this.CarUsageResults.Name = "CarUsageResults";
+            this.CarUsageResults.Size = new System.Drawing.Size(772, 255);
+            this.CarUsageResults.TabIndex = 2;
+            // 
+            // ReportTab2
+            // 
+            this.ReportTab2.Controls.Add(this.FrequentFlyersSubmit);
+            this.ReportTab2.Controls.Add(this.FrequentFlyerResults);
+            this.ReportTab2.Location = new System.Drawing.Point(4, 22);
+            this.ReportTab2.Name = "ReportTab2";
+            this.ReportTab2.Padding = new System.Windows.Forms.Padding(3);
+            this.ReportTab2.Size = new System.Drawing.Size(902, 505);
+            this.ReportTab2.TabIndex = 1;
+            this.ReportTab2.Text = "Frequent Flyers";
+            this.ReportTab2.UseVisualStyleBackColor = true;
+            // 
+            // FrequentFlyerResults
+            // 
+            this.FrequentFlyerResults.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.FrequentFlyerResults.Location = new System.Drawing.Point(65, 185);
+            this.FrequentFlyerResults.Name = "FrequentFlyerResults";
+            this.FrequentFlyerResults.Size = new System.Drawing.Size(772, 255);
+            this.FrequentFlyerResults.TabIndex = 1;
+            // 
+            // ReportTab3
+            // 
+            this.ReportTab3.Controls.Add(this.MonthlyRevenueSubmit);
+            this.ReportTab3.Controls.Add(this.MonthlyRevenueResults);
+            this.ReportTab3.Location = new System.Drawing.Point(4, 22);
+            this.ReportTab3.Name = "ReportTab3";
+            this.ReportTab3.Size = new System.Drawing.Size(902, 505);
+            this.ReportTab3.TabIndex = 2;
+            this.ReportTab3.Text = "Monthly Revenue";
+            this.ReportTab3.UseVisualStyleBackColor = true;
+            // 
+            // MonthlyRevenueResults
+            // 
+            this.MonthlyRevenueResults.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.MonthlyRevenueResults.Location = new System.Drawing.Point(65, 185);
+            this.MonthlyRevenueResults.Name = "MonthlyRevenueResults";
+            this.MonthlyRevenueResults.Size = new System.Drawing.Size(772, 255);
+            this.MonthlyRevenueResults.TabIndex = 1;
+            // 
+            // ReportTab4
+            // 
+            this.ReportTab4.Controls.Add(this.BusyBranchTimesSubmit);
+            this.ReportTab4.Controls.Add(this.BusyBranchTimesResults);
+            this.ReportTab4.Location = new System.Drawing.Point(4, 22);
+            this.ReportTab4.Name = "ReportTab4";
+            this.ReportTab4.Size = new System.Drawing.Size(902, 505);
+            this.ReportTab4.TabIndex = 3;
+            this.ReportTab4.Text = "Busy Branch Times";
+            this.ReportTab4.UseVisualStyleBackColor = true;
+            // 
+            // BusyBranchTimesResults
+            // 
+            this.BusyBranchTimesResults.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.BusyBranchTimesResults.Location = new System.Drawing.Point(65, 185);
+            this.BusyBranchTimesResults.Name = "BusyBranchTimesResults";
+            this.BusyBranchTimesResults.Size = new System.Drawing.Size(772, 255);
+            this.BusyBranchTimesResults.TabIndex = 1;
+            // 
+            // ReportTab5
+            // 
+            this.ReportTab5.Controls.Add(this.UnderPerformingEmpsSubmit);
+            this.ReportTab5.Controls.Add(this.UnderPerformingEmpsResults);
+            this.ReportTab5.Location = new System.Drawing.Point(4, 22);
+            this.ReportTab5.Name = "ReportTab5";
+            this.ReportTab5.Size = new System.Drawing.Size(902, 505);
+            this.ReportTab5.TabIndex = 4;
+            this.ReportTab5.Text = "Under-performing Employees";
+            this.ReportTab5.UseVisualStyleBackColor = true;
+            // 
+            // BackButton
+            // 
+            this.BackButton.Location = new System.Drawing.Point(802, 5);
+            this.BackButton.Margin = new System.Windows.Forms.Padding(2);
+            this.BackButton.Name = "BackButton";
+            this.BackButton.Size = new System.Drawing.Size(103, 23);
+            this.BackButton.TabIndex = 5;
+            this.BackButton.Text = "Back";
+            this.BackButton.UseVisualStyleBackColor = true;
+            this.BackButton.Click += new System.EventHandler(this.BackButtonClick);
+            // 
+            // UnderPerformingEmpsResults
+            // 
+            this.UnderPerformingEmpsResults.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.UnderPerformingEmpsResults.Location = new System.Drawing.Point(65, 185);
+            this.UnderPerformingEmpsResults.Name = "UnderPerformingEmpsResults";
+            this.UnderPerformingEmpsResults.Size = new System.Drawing.Size(772, 255);
+            this.UnderPerformingEmpsResults.TabIndex = 1;
+            // 
+            // UnderPerformingEmpsSubmit
+            // 
+            this.UnderPerformingEmpsSubmit.Location = new System.Drawing.Point(733, 447);
+            this.UnderPerformingEmpsSubmit.Margin = new System.Windows.Forms.Padding(2);
+            this.UnderPerformingEmpsSubmit.Name = "UnderPerformingEmpsSubmit";
+            this.UnderPerformingEmpsSubmit.Size = new System.Drawing.Size(104, 41);
+            this.UnderPerformingEmpsSubmit.TabIndex = 6;
+            this.UnderPerformingEmpsSubmit.Text = "Run Report";
+            this.UnderPerformingEmpsSubmit.UseVisualStyleBackColor = true;
+            this.UnderPerformingEmpsSubmit.Click += new System.EventHandler(this.UnderPerformingEmpsSubmit_Click);
+            // 
+            // BusyBranchTimesSubmit
+            // 
+            this.BusyBranchTimesSubmit.Location = new System.Drawing.Point(733, 447);
+            this.BusyBranchTimesSubmit.Margin = new System.Windows.Forms.Padding(2);
+            this.BusyBranchTimesSubmit.Name = "BusyBranchTimesSubmit";
+            this.BusyBranchTimesSubmit.Size = new System.Drawing.Size(104, 41);
+            this.BusyBranchTimesSubmit.TabIndex = 7;
+            this.BusyBranchTimesSubmit.Text = "Run Report";
+            this.BusyBranchTimesSubmit.UseVisualStyleBackColor = true;
+            this.BusyBranchTimesSubmit.Click += new System.EventHandler(this.BusyBranchTimesSubmit_Click);
+            // 
+            // MonthlyRevenueSubmit
+            // 
+            this.MonthlyRevenueSubmit.Location = new System.Drawing.Point(733, 447);
+            this.MonthlyRevenueSubmit.Margin = new System.Windows.Forms.Padding(2);
+            this.MonthlyRevenueSubmit.Name = "MonthlyRevenueSubmit";
+            this.MonthlyRevenueSubmit.Size = new System.Drawing.Size(104, 41);
+            this.MonthlyRevenueSubmit.TabIndex = 7;
+            this.MonthlyRevenueSubmit.Text = "Run Report";
+            this.MonthlyRevenueSubmit.UseVisualStyleBackColor = true;
+            this.MonthlyRevenueSubmit.Click += new System.EventHandler(this.MonthlyRevenueSubmit_Click);
+            // 
+            // FrequentFlyersSubmit
+            // 
+            this.FrequentFlyersSubmit.Location = new System.Drawing.Point(733, 447);
+            this.FrequentFlyersSubmit.Margin = new System.Windows.Forms.Padding(2);
+            this.FrequentFlyersSubmit.Name = "FrequentFlyersSubmit";
+            this.FrequentFlyersSubmit.Size = new System.Drawing.Size(104, 41);
+            this.FrequentFlyersSubmit.TabIndex = 7;
+            this.FrequentFlyersSubmit.Text = "Run Report";
+            this.FrequentFlyersSubmit.UseVisualStyleBackColor = true;
+            this.FrequentFlyersSubmit.Click += new System.EventHandler(this.FrequentFlyersSubmit_Click);
+            // 
+            // CarUsagesSubmit
+            // 
+            this.CarUsagesSubmit.Location = new System.Drawing.Point(733, 447);
+            this.CarUsagesSubmit.Margin = new System.Windows.Forms.Padding(2);
+            this.CarUsagesSubmit.Name = "CarUsagesSubmit";
+            this.CarUsagesSubmit.Size = new System.Drawing.Size(104, 41);
+            this.CarUsagesSubmit.TabIndex = 7;
+            this.CarUsagesSubmit.Text = "Run Report";
+            this.CarUsagesSubmit.UseVisualStyleBackColor = true;
+            this.CarUsagesSubmit.Click += new System.EventHandler(this.CarUsagesSubmit_Click);
+            // 
+            // ReportFormNew
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(907, 543);
+            this.Controls.Add(this.BackButton);
+            this.Controls.Add(this.TabControlMenu);
+            this.Name = "ReportFormNew";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Reports";
+            this.Load += new System.EventHandler(this.ReportFormNew_Load);
+            this.TabControlMenu.ResumeLayout(false);
+            this.ReportTab1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.CarUsageResults)).EndInit();
+            this.ReportTab2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.FrequentFlyerResults)).EndInit();
+            this.ReportTab3.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.MonthlyRevenueResults)).EndInit();
+            this.ReportTab4.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.BusyBranchTimesResults)).EndInit();
+            this.ReportTab5.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.UnderPerformingEmpsResults)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TabControl TabControlMenu;
+        private System.Windows.Forms.TabPage ReportTab1;
+        private System.Windows.Forms.TabPage ReportTab2;
+        private System.Windows.Forms.TabPage ReportTab3;
+        private System.Windows.Forms.TabPage ReportTab4;
+        private System.Windows.Forms.TabPage ReportTab5;
+        private System.Windows.Forms.DataGridView CarUsageResults;
+        private System.Windows.Forms.DataGridView FrequentFlyerResults;
+        private System.Windows.Forms.DataGridView MonthlyRevenueResults;
+        private System.Windows.Forms.DataGridView BusyBranchTimesResults;
+        private System.Windows.Forms.DataGridView UnderPerformingEmpsResults;
+        private System.Windows.Forms.Button BackButton;
+        private System.Windows.Forms.Button CarUsagesSubmit;
+        private System.Windows.Forms.Button FrequentFlyersSubmit;
+        private System.Windows.Forms.Button MonthlyRevenueSubmit;
+        private System.Windows.Forms.Button BusyBranchTimesSubmit;
+        private System.Windows.Forms.Button UnderPerformingEmpsSubmit;
+    }
+}

--- a/ReportFormNew.cs
+++ b/ReportFormNew.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace Team1CMPT291_Final
+{
+    public partial class ReportFormNew : Form
+    {
+
+        private DBConnection DBConnectionInstance;
+
+        public ReportFormNew()
+        {
+            InitializeComponent();
+            DBConnectionInstance = new DBConnection();
+        }
+
+        private void ReportFormNew_Load(object sender, EventArgs e)
+        {
+
+        }
+
+        private void BackButtonClick(object sender, EventArgs e)
+        {
+            Close();
+            var mainScreenForm = new MainScreenForm();
+            mainScreenForm.Show();
+        }
+
+        private void CarUsagesSubmit_Click(object sender, EventArgs e)
+        {
+            var query   = "SELECT * FROM CarType WHERE Type = 'SMALL'";
+            var results = DBConnectionInstance.Query(query);
+            CarUsageResults.DataSource = results;
+        }
+
+        private void FrequentFlyersSubmit_Click(object sender, EventArgs e)
+        {
+            var query   = "SELECT * FROM CarType WHERE Type = 'SMALL'";
+            var results = DBConnectionInstance.Query(query);
+            FrequentFlyerResults.DataSource = results;
+        }
+
+        private void MonthlyRevenueSubmit_Click(object sender, EventArgs e)
+        {
+            var query   = "SELECT * FROM CarType WHERE Type = 'SMALL'";
+            var results = DBConnectionInstance.Query(query);
+            MonthlyRevenueResults.DataSource = results;
+        }
+
+        private void BusyBranchTimesSubmit_Click(object sender, EventArgs e)
+        {
+            var query   = "SELECT * FROM CarType WHERE Type = 'SMALL'";
+            var results = DBConnectionInstance.Query(query);
+            BusyBranchTimesResults.DataSource = results;
+        }
+
+        private void UnderPerformingEmpsSubmit_Click(object sender, EventArgs e)
+        {
+            var query   = "SELECT * FROM CarType WHERE Type = 'SMALL'";
+            var results = DBConnectionInstance.Query(query);
+            UnderPerformingEmpsResults.DataSource = results;
+        }
+    }
+}

--- a/ReportFormNew.resx
+++ b/ReportFormNew.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Team1CMPT291_Final.csproj
+++ b/Team1CMPT291_Final.csproj
@@ -91,6 +91,12 @@
     <Compile Include="ReportForm.Designer.cs">
       <DependentUpon>ReportForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="ReportFormNew.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ReportFormNew.Designer.cs">
+      <DependentUpon>ReportFormNew.cs</DependentUpon>
+    </Compile>
     <EmbeddedResource Include="AddCarForm.resx">
       <DependentUpon>AddCarForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -120,6 +126,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ReportForm.resx">
       <DependentUpon>ReportForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ReportFormNew.resx">
+      <DependentUpon>ReportFormNew.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>


### PR DESCRIPTION
![Screenshot 2024-06-11 183405](https://github.com/Fishington/CMPT291S2024_Team1/assets/66894405/77a6b94e-4a3a-401d-89ba-22b68912e1e4)
![Screenshot 2024-06-11 183451](https://github.com/Fishington/CMPT291S2024_Team1/assets/66894405/2c256284-97a3-42bc-897f-262895cfd536)

- Added a new report form that has TabControl. Each of us can have our own tab + results to customize as desired (see screenshots)
- The MinDate for DateTimePickers in reservations is now dynamic (updates based on current day)
- Each form opens centrally on the screen now for consistency